### PR TITLE
update to opencv3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # SLIC Superpixel Implementation, originally from : https://github.com/PSMM/SLIC-Superpixels
 
-modified to work with cv::Mat, not using the deprecated c-api.
-
-
 This repository contains an implementation of the SLIC Superpixel algorithm by Achanta et al. (PAMI'12, vol. 34, num. 11, pp. 2274-2282). The C++ implementation is created to work with the strutures of OpenCV.
 
 ## Exemplary result

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# SLIC Superpixel Implementation
+# SLIC Superpixel Implementation, originally from : https://github.com/PSMM/SLIC-Superpixels
+
+modified to work with cv::Mat, not using the deprecated c-api.
+
+
 This repository contains an implementation of the SLIC Superpixel algorithm by Achanta et al. (PAMI'12, vol. 34, num. 11, pp. 2274-2282). The C++ implementation is created to work with the strutures of OpenCV.
 
 ## Exemplary result

--- a/slic.cpp
+++ b/slic.cpp
@@ -1,5 +1,7 @@
 #include "slic.h"
 
+
+
 /*
  * Constructor. Nothing is done here.
  */
@@ -21,9 +23,10 @@ Slic::~Slic() {
  * Output: -
  */
 void Slic::clear_data() {
-    clusters.clear();
-    distances.clear();
-    centers.clear();
+    clusters.release();
+    distances.release();
+    centers.release();
+    //centers.clear();
     center_counts.clear();
 }
 
@@ -36,31 +39,19 @@ void Slic::clear_data() {
  */
 void Slic::init_data(const cv::Mat &image) {
     /* Initialize the cluster and distance matrices. */
-    for (int i = 0; i < image.cols; i++) { 
-        vector<int> cr;
-        vector<double> dr;
-        for (int j = 0; j < image.rows; j++) {
-            cr.push_back(-1);
-            dr.push_back(FLT_MAX);
-        }
-        clusters.push_back(cr);
-        distances.push_back(dr);
-    }
-    
+
+    clusters = Mat_<int>(image.cols,image.rows,-1);
+    distances = Mat_<double>(image.cols,image.rows,FLT_MAX);
+
     /* Initialize the centers and counters. */
     for (int i = step; i < image.cols - step/2; i += step) {
         for (int j = step; j < image.rows - step/2; j += step) {
-            vector<double> center;
             /* Find the local minimum (gradient-wise). */
             cv::Point nc = find_local_minimum(image, cv::Point(i,j));
             cv::Scalar colour = image.at<Vec3b>(nc.y, nc.x);
             
             /* Generate the center vector. */
-            center.push_back(colour.val[0]);
-            center.push_back(colour.val[1]);
-            center.push_back(colour.val[2]);
-            center.push_back(nc.x);
-            center.push_back(nc.y);
+            Vec5d center(colour.val[0],colour.val[1],colour.val[2],nc.x,nc.y);
             
             /* Append to vector of centers. */
             centers.push_back(center);
@@ -77,9 +68,10 @@ void Slic::init_data(const cv::Mat &image) {
  * Output: The distance (double).
  */
 double Slic::compute_dist(int ci, cv::Point pixel, cv::Scalar colour) {
-    double dc = sqrt(pow(centers[ci][0] - colour.val[0], 2) + pow(centers[ci][1]
-            - colour.val[1], 2) + pow(centers[ci][2] - colour.val[2], 2));
-    double ds = sqrt(pow(centers[ci][3] - pixel.x, 2) + pow(centers[ci][4] - pixel.y, 2));
+    Vec5d cen(centers(ci));
+    double dc = sqrt(pow(cen[0] - colour.val[0], 2) + pow(cen[1]
+            - colour.val[1], 2) + pow(cen[2] - colour.val[2], 2));
+    double ds = sqrt(pow(cen[3] - pixel.x, 2) + pow(cen[4] - pixel.y, 2));
     
     return sqrt(pow(dc / nc, 2) + pow(ds / ns, 2));
     
@@ -94,15 +86,15 @@ double Slic::compute_dist(int ci, cv::Point pixel, cv::Scalar colour) {
  * Input : The image (cv::Mat &) and the pixel center (cv::Point).
  * Output: The local gradient minimum (cv::Point).
  */
-cv::Point Slic::find_local_minimum(const cv::Mat &image, cv::Point center) {
+cv::Point Slic::find_local_minimum(const cv::Mat_<Vec3b> &image, cv::Point center) {
     double min_grad = FLT_MAX;
     cv::Point loc_min = cv::Point(center.x, center.y);
     
     for (int i = center.x-1; i < center.x+2; i++) {
         for (int j = center.y-1; j < center.y+2; j++) {
-            cv::Scalar c1 = image.at<Vec3b>(j+1, i);
-            cv::Scalar c2 = image.at<Vec3b>(j, i+1);
-            cv::Scalar c3 = image.at<Vec3b>(j, i);
+            cv::Scalar c1 = image(j+1, i);
+            cv::Scalar c2 = image(j, i+1);
+            cv::Scalar c3 = image(j, i);
             /* Convert colour values to grayscale values. */
             double i1 = c1.val[0];
             double i2 = c2.val[0];
@@ -128,14 +120,16 @@ cv::Point Slic::find_local_minimum(const cv::Mat &image, cv::Point center) {
  * Compute the over-segmentation based on the step-size and relative weighting
  * of the pixel and colour values.
  *
- * Input : The Lab image (IplImage*), the stepsize (int), and the weight (int).
+ * Input : The Lab image (cv::Mat), the stepsize (int), and the weight (int).
  * Output: -
  */
-void Slic::generate_superpixels(const cv::Mat &image, int step, int nc) {
+void Slic::generate_superpixels(const cv::Mat &img, int step, int nc) {
     this->step = step;
     this->nc = nc;
     this->ns = step;
-    
+
+    Mat_<Vec3b> image(img);
+
     /* Clear previous data (if any), and re-initialize it. */
     clear_data();
     init_data(image);
@@ -143,26 +137,23 @@ void Slic::generate_superpixels(const cv::Mat &image, int step, int nc) {
     /* Run EM for 10 iterations (as prescribed by the algorithm). */
     for (int i = 0; i < NR_ITERATIONS; i++) {
         /* Reset distance values. */
-        for (int j = 0; j < image.cols; j++) {
-            for (int k = 0;k < image.rows; k++) {
-                distances[j][k] = FLT_MAX;
-            }
-        }
+        distances = FLT_MAX;
 
-        for (int j = 0; j < (int) centers.size(); j++) {
+        for (int j = 0; j < centers.rows; j++) {
             /* Only compare to pixels in a 2 x step by 2 x step region. */
-            for (int k = int(centers[j][3]) - step; k < int(centers[j][3]) + step; k++) {
-                for (int l = int(centers[j][4]) - step; l < int(centers[j][4]) + step; l++) {
+            Vec5d cen(centers(j));
+            for (int k = int(cen[3]) - step; k < int(cen[3]) + step; k++) {
+                for (int l = int(cen[4]) - step; l < int(cen[4]) + step; l++) {
                 
                     if (k >= 0 && k < image.cols && l >= 0 && l < image.rows) {
-                        cv::Scalar colour = image.at<Vec3b>(l, k);
+                        cv::Scalar colour = image(l, k);
                         double d = compute_dist(j, cv::Point(k,l), colour);
                         
                         /* Update cluster allocation if the cluster minimizes the
                            distance. */
-                        if (d < distances[k][l]) {
-                            distances[k][l] = d;
-                            clusters[k][l] = j;
+                        if (d < distances(k,l)) {
+                            distances(k,l) = d;
+                            clusters(k,l) = j;
                         }
                     }
                 }
@@ -170,37 +161,27 @@ void Slic::generate_superpixels(const cv::Mat &image, int step, int nc) {
         }
         
         /* Clear the center values. */
-        for (int j = 0; j < (int) centers.size(); j++) {
-            centers[j][0] = centers[j][1] = centers[j][2] = centers[j][3] = centers[j][4] = 0;
+        for (int j = 0; j < centers.rows; j++) {
+            centers(j) = 0;
             center_counts[j] = 0;
         }
         
         /* Compute the new cluster centers. */
         for (int j = 0; j < image.cols; j++) {
             for (int k = 0; k < image.rows; k++) {
-                int c_id = clusters[j][k];
+                int c_id = clusters(j,k);
                 
                 if (c_id != -1) {
-                    cv::Scalar colour = image.at<Vec3b>(k, j);
-                    
-                    centers[c_id][0] += colour.val[0];
-                    centers[c_id][1] += colour.val[1];
-                    centers[c_id][2] += colour.val[2];
-                    centers[c_id][3] += j;
-                    centers[c_id][4] += k;
-                    
+                    cv::Scalar colour = image(k, j);                    
+                    centers(c_id) += Vec5d(colour.val[0], colour.val[1], colour.val[2], j, k);                    
                     center_counts[c_id] += 1;
                 }
             }
         }
 
         /* Normalize the clusters. */
-        for (int j = 0; j < (int) centers.size(); j++) {
-            centers[j][0] /= center_counts[j];
-            centers[j][1] /= center_counts[j];
-            centers[j][2] /= center_counts[j];
-            centers[j][3] /= center_counts[j];
-            centers[j][4] /= center_counts[j];
+        for (int j = 0; j < centers.rows; j++) {
+            centers(j) /= center_counts[j];
         }
     }
 }
@@ -215,24 +196,17 @@ void Slic::generate_superpixels(const cv::Mat &image, int step, int nc) {
  */
 void Slic::create_connectivity(const cv::Mat &image) {
     int label = 0, adjlabel = 0;
-    const int lims = (image.cols * image.rows) / ((int)centers.size());
+    const int lims = (image.cols * image.rows) / (centers.rows);
     
     const int dx4[4] = {-1,  0,  1,  0};
 	const int dy4[4] = { 0, -1,  0,  1};
     
     /* Initialize the new cluster matrix. */
-    vec2di new_clusters;
-    for (int i = 0; i < image.cols; i++) { 
-        vector<int> nc;
-        for (int j = 0; j < image.rows; j++) {
-            nc.push_back(-1);
-        }
-        new_clusters.push_back(nc);
-    }
+    Mat_<int> new_clusters(image.cols,image.rows,-1);
 
     for (int i = 0; i < image.cols; i++) {
         for (int j = 0; j < image.rows; j++) {
-            if (new_clusters[i][j] == -1) {
+            if (new_clusters(i,j) == -1) {
                 vector<cv::Point> elements;
                 elements.push_back(cv::Point(i, j));
             
@@ -241,8 +215,8 @@ void Slic::create_connectivity(const cv::Mat &image) {
                     int x = elements[0].x + dx4[k], y = elements[0].y + dy4[k];
                     
                     if (x >= 0 && x < image.cols && y >= 0 && y < image.rows) {
-                        if (new_clusters[x][y] >= 0) {
-                            adjlabel = new_clusters[x][y];
+                        if (new_clusters(x,y) >= 0) {
+                            adjlabel = new_clusters(x,y);
                         }
                     }
                 }
@@ -253,9 +227,9 @@ void Slic::create_connectivity(const cv::Mat &image) {
                         int x = elements[c].x + dx4[k], y = elements[c].y + dy4[k];
                         
                         if (x >= 0 && x < image.cols && y >= 0 && y < image.rows) {
-                            if (new_clusters[x][y] == -1 && clusters[i][j] == clusters[x][y]) {
+                            if (new_clusters(x,y) == -1 && clusters(i,j) == clusters(x,y)) {
                                 elements.push_back(cv::Point(x, y));
-                                new_clusters[x][y] = label;
+                                new_clusters(x,y) = label;
                                 count += 1;
                             }
                         }
@@ -266,7 +240,7 @@ void Slic::create_connectivity(const cv::Mat &image) {
                    smaller than a limit. */
                 if (count <= lims >> 2) {
                     for (int c = 0; c < count; c++) {
-                        new_clusters[elements[c].x][elements[c].y] = adjlabel;
+                        new_clusters(elements[c].x, elements[c].y) = adjlabel;
                     }
                     label -= 1;
                 }
@@ -283,8 +257,8 @@ void Slic::create_connectivity(const cv::Mat &image) {
  * Output: -
  */
 void Slic::display_center_grid(cv::Mat &image, cv::Vec3b colour) {
-    for (int i = 0; i < (int) centers.size(); i++) {
-        cv::circle(image, cv::Point2d(centers[i][3], centers[i][4]), 2, colour, 2);
+    for (int i = 0; i < centers.rows; i++) {
+        cv::circle(image, cv::Point2d(centers(i)[3], centers(i)[4]), 2, colour, 2);
     }
 }
 
@@ -301,14 +275,7 @@ void Slic::display_contours(cv::Mat &image, cv::Vec3b colour) {
 	/* Initialize the contour vector and the matrix detailing whether a pixel
 	 * is already taken to be a contour. */
 	vector<cv::Point> contours;
-	vec2db istaken;
-	for (int i = 0; i < image.cols; i++) { 
-        vector<bool> nb;
-        for (int j = 0; j < image.rows; j++) {
-            nb.push_back(false);
-        }
-        istaken.push_back(nb);
-    }
+	Mat_<uchar> istaken(image.cols, image.rows, uchar(0));
     
     /* Go through all the pixels. */
     for (int i = 0; i < image.cols; i++) {
@@ -320,7 +287,7 @@ void Slic::display_contours(cv::Mat &image, cv::Vec3b colour) {
                 int x = i + dx8[k], y = j + dy8[k];
                 
                 if (x >= 0 && x < image.cols && y >= 0 && y < image.rows) {
-                    if (istaken[x][y] == false && clusters[i][j] != clusters[x][y]) {
+                    if (istaken(x,y) == false && clusters(i,j) != clusters(x,y)) {
                         nr_p += 1;
                     }
                 }
@@ -329,7 +296,7 @@ void Slic::display_contours(cv::Mat &image, cv::Vec3b colour) {
             /* Add the pixel to the contour list if desired. */
             if (nr_p >= 2) {
                 contours.push_back(cv::Point(i,j));
-                istaken[i][j] = true;
+                istaken(i,j) = true;
             }
         }
     }
@@ -348,12 +315,12 @@ void Slic::display_contours(cv::Mat &image, cv::Vec3b colour) {
  * Output: -
  */
 void Slic::colour_with_cluster_means(cv::Mat &image) {
-    vector<cv::Vec3b> colours(centers.size());
+    vector<cv::Vec3b> colours(centers.rows);
     
     /* Gather the colour values per cluster. */
     for (int i = 0; i < image.cols; i++) {
         for (int j = 0; j < image.rows; j++) {
-            int index = clusters[i][j];
+            int index = clusters(i,j);
             colours[index] += image.at<Vec3b>(j, i);
         }
     }
@@ -366,7 +333,7 @@ void Slic::colour_with_cluster_means(cv::Mat &image) {
     /* Fill in. */
     for (int i = 0; i < image.cols; i++) {
         for (int j = 0; j < image.rows; j++) {
-            image.at<Vec3b>(j, i) = colours[clusters[i][j]];;
+            image.at<Vec3b>(j, i) = colours[clusters(i,j)];;
         }
     }
 }

--- a/slic.cpp
+++ b/slic.cpp
@@ -248,6 +248,7 @@ void Slic::create_connectivity(const cv::Mat &image) {
             }
         }
     }
+    clusters = new_clusters;
 }
 
 /*

--- a/slic.cpp
+++ b/slic.cpp
@@ -256,7 +256,7 @@ void Slic::create_connectivity(const cv::Mat &image) {
  * Input : The image to display upon (cv::Mat) and the colour (cv::Vec3b).
  * Output: -
  */
-void Slic::display_center_grid(cv::Mat &image, cv::Vec3b colour) {
+void Slic::display_center_grid(cv::Mat &image, cv::Scalar colour) {
     for (int i = 0; i < centers.rows; i++) {
         cv::circle(image, cv::Point2d(centers(i)[3], centers(i)[4]), 2, colour, 2);
     }

--- a/slic.cpp
+++ b/slic.cpp
@@ -31,15 +31,15 @@ void Slic::clear_data() {
  * Initialize the cluster centers and initial values of the pixel-wise cluster
  * assignment and distance values.
  *
- * Input : The image (IplImage*).
+ * Input : The image (cv::Mat).
  * Output: -
  */
-void Slic::init_data(IplImage *image) {
+void Slic::init_data(const cv::Mat &image) {
     /* Initialize the cluster and distance matrices. */
-    for (int i = 0; i < image->width; i++) { 
+    for (int i = 0; i < image.cols; i++) { 
         vector<int> cr;
         vector<double> dr;
-        for (int j = 0; j < image->height; j++) {
+        for (int j = 0; j < image.rows; j++) {
             cr.push_back(-1);
             dr.push_back(FLT_MAX);
         }
@@ -48,12 +48,12 @@ void Slic::init_data(IplImage *image) {
     }
     
     /* Initialize the centers and counters. */
-    for (int i = step; i < image->width - step/2; i += step) {
-        for (int j = step; j < image->height - step/2; j += step) {
+    for (int i = step; i < image.cols - step/2; i += step) {
+        for (int j = step; j < image.rows - step/2; j += step) {
             vector<double> center;
             /* Find the local minimum (gradient-wise). */
-            CvPoint nc = find_local_minimum(image, cvPoint(i,j));
-            CvScalar colour = cvGet2D(image, nc.y, nc.x);
+            cv::Point nc = find_local_minimum(image, cv::Point(i,j));
+            cv::Scalar colour = image.at<Vec3b>(nc.y, nc.x);
             
             /* Generate the center vector. */
             center.push_back(colour.val[0]);
@@ -72,11 +72,11 @@ void Slic::init_data(IplImage *image) {
 /*
  * Compute the distance between a cluster center and an individual pixel.
  *
- * Input : The cluster index (int), the pixel (CvPoint), and the Lab values of
- *         the pixel (CvScalar).
+ * Input : The cluster index (int), the pixel (cv::Point), and the Lab values of
+ *         the pixel (cv::Scalar).
  * Output: The distance (double).
  */
-double Slic::compute_dist(int ci, CvPoint pixel, CvScalar colour) {
+double Slic::compute_dist(int ci, cv::Point pixel, cv::Scalar colour) {
     double dc = sqrt(pow(centers[ci][0] - colour.val[0], 2) + pow(centers[ci][1]
             - colour.val[1], 2) + pow(centers[ci][2] - colour.val[2], 2));
     double ds = sqrt(pow(centers[ci][3] - pixel.x, 2) + pow(centers[ci][4] - pixel.y, 2));
@@ -91,18 +91,18 @@ double Slic::compute_dist(int ci, CvPoint pixel, CvScalar colour) {
  * Find a local gradient minimum of a pixel in a 3x3 neighbourhood. This
  * method is called upon initialization of the cluster centers.
  *
- * Input : The image (IplImage*) and the pixel center (CvPoint).
- * Output: The local gradient minimum (CvPoint).
+ * Input : The image (cv::Mat &) and the pixel center (cv::Point).
+ * Output: The local gradient minimum (cv::Point).
  */
-CvPoint Slic::find_local_minimum(IplImage *image, CvPoint center) {
+cv::Point Slic::find_local_minimum(const cv::Mat &image, cv::Point center) {
     double min_grad = FLT_MAX;
-    CvPoint loc_min = cvPoint(center.x, center.y);
+    cv::Point loc_min = cv::Point(center.x, center.y);
     
     for (int i = center.x-1; i < center.x+2; i++) {
         for (int j = center.y-1; j < center.y+2; j++) {
-            CvScalar c1 = cvGet2D(image, j+1, i);
-            CvScalar c2 = cvGet2D(image, j, i+1);
-            CvScalar c3 = cvGet2D(image, j, i);
+            cv::Scalar c1 = image.at<Vec3b>(j+1, i);
+            cv::Scalar c2 = image.at<Vec3b>(j, i+1);
+            cv::Scalar c3 = image.at<Vec3b>(j, i);
             /* Convert colour values to grayscale values. */
             double i1 = c1.val[0];
             double i2 = c2.val[0];
@@ -131,7 +131,7 @@ CvPoint Slic::find_local_minimum(IplImage *image, CvPoint center) {
  * Input : The Lab image (IplImage*), the stepsize (int), and the weight (int).
  * Output: -
  */
-void Slic::generate_superpixels(IplImage *image, int step, int nc) {
+void Slic::generate_superpixels(const cv::Mat &image, int step, int nc) {
     this->step = step;
     this->nc = nc;
     this->ns = step;
@@ -143,20 +143,20 @@ void Slic::generate_superpixels(IplImage *image, int step, int nc) {
     /* Run EM for 10 iterations (as prescribed by the algorithm). */
     for (int i = 0; i < NR_ITERATIONS; i++) {
         /* Reset distance values. */
-        for (int j = 0; j < image->width; j++) {
-            for (int k = 0;k < image->height; k++) {
+        for (int j = 0; j < image.cols; j++) {
+            for (int k = 0;k < image.rows; k++) {
                 distances[j][k] = FLT_MAX;
             }
         }
 
         for (int j = 0; j < (int) centers.size(); j++) {
             /* Only compare to pixels in a 2 x step by 2 x step region. */
-            for (int k = centers[j][3] - step; k < centers[j][3] + step; k++) {
-                for (int l = centers[j][4] - step; l < centers[j][4] + step; l++) {
+            for (int k = int(centers[j][3]) - step; k < int(centers[j][3]) + step; k++) {
+                for (int l = int(centers[j][4]) - step; l < int(centers[j][4]) + step; l++) {
                 
-                    if (k >= 0 && k < image->width && l >= 0 && l < image->height) {
-                        CvScalar colour = cvGet2D(image, l, k);
-                        double d = compute_dist(j, cvPoint(k,l), colour);
+                    if (k >= 0 && k < image.cols && l >= 0 && l < image.rows) {
+                        cv::Scalar colour = image.at<Vec3b>(l, k);
+                        double d = compute_dist(j, cv::Point(k,l), colour);
                         
                         /* Update cluster allocation if the cluster minimizes the
                            distance. */
@@ -176,12 +176,12 @@ void Slic::generate_superpixels(IplImage *image, int step, int nc) {
         }
         
         /* Compute the new cluster centers. */
-        for (int j = 0; j < image->width; j++) {
-            for (int k = 0; k < image->height; k++) {
+        for (int j = 0; j < image.cols; j++) {
+            for (int k = 0; k < image.rows; k++) {
                 int c_id = clusters[j][k];
                 
                 if (c_id != -1) {
-                    CvScalar colour = cvGet2D(image, k, j);
+                    cv::Scalar colour = image.at<Vec3b>(k, j);
                     
                     centers[c_id][0] += colour.val[0];
                     centers[c_id][1] += colour.val[1];
@@ -210,37 +210,37 @@ void Slic::generate_superpixels(IplImage *image, int step, int nc) {
  * in the paper, but forms an active part of the implementation of the authors
  * of the paper.
  *
- * Input : The image (IplImage*).
+ * Input : The image (cv::Mat).
  * Output: -
  */
-void Slic::create_connectivity(IplImage *image) {
+void Slic::create_connectivity(const cv::Mat &image) {
     int label = 0, adjlabel = 0;
-    const int lims = (image->width * image->height) / ((int)centers.size());
+    const int lims = (image.cols * image.rows) / ((int)centers.size());
     
     const int dx4[4] = {-1,  0,  1,  0};
 	const int dy4[4] = { 0, -1,  0,  1};
     
     /* Initialize the new cluster matrix. */
     vec2di new_clusters;
-    for (int i = 0; i < image->width; i++) { 
+    for (int i = 0; i < image.cols; i++) { 
         vector<int> nc;
-        for (int j = 0; j < image->height; j++) {
+        for (int j = 0; j < image.rows; j++) {
             nc.push_back(-1);
         }
         new_clusters.push_back(nc);
     }
 
-    for (int i = 0; i < image->width; i++) {
-        for (int j = 0; j < image->height; j++) {
+    for (int i = 0; i < image.cols; i++) {
+        for (int j = 0; j < image.rows; j++) {
             if (new_clusters[i][j] == -1) {
-                vector<CvPoint> elements;
-                elements.push_back(cvPoint(i, j));
+                vector<cv::Point> elements;
+                elements.push_back(cv::Point(i, j));
             
                 /* Find an adjacent label, for possible use later. */
                 for (int k = 0; k < 4; k++) {
                     int x = elements[0].x + dx4[k], y = elements[0].y + dy4[k];
                     
-                    if (x >= 0 && x < image->width && y >= 0 && y < image->height) {
+                    if (x >= 0 && x < image.cols && y >= 0 && y < image.rows) {
                         if (new_clusters[x][y] >= 0) {
                             adjlabel = new_clusters[x][y];
                         }
@@ -252,9 +252,9 @@ void Slic::create_connectivity(IplImage *image) {
                     for (int k = 0; k < 4; k++) {
                         int x = elements[c].x + dx4[k], y = elements[c].y + dy4[k];
                         
-                        if (x >= 0 && x < image->width && y >= 0 && y < image->height) {
+                        if (x >= 0 && x < image.cols && y >= 0 && y < image.rows) {
                             if (new_clusters[x][y] == -1 && clusters[i][j] == clusters[x][y]) {
-                                elements.push_back(cvPoint(x, y));
+                                elements.push_back(cv::Point(x, y));
                                 new_clusters[x][y] = label;
                                 count += 1;
                             }
@@ -279,47 +279,47 @@ void Slic::create_connectivity(IplImage *image) {
 /*
  * Display the cluster centers.
  *
- * Input : The image to display upon (IplImage*) and the colour (CvScalar).
+ * Input : The image to display upon (IplImage*) and the colour (cv::Scalar).
  * Output: -
  */
-void Slic::display_center_grid(IplImage *image, CvScalar colour) {
+void Slic::display_center_grid(cv::Mat &image, cv::Vec3b colour) {
     for (int i = 0; i < (int) centers.size(); i++) {
-        cvCircle(image, cvPoint(centers[i][3], centers[i][4]), 2, colour, 2);
+        cv::circle(image, cv::Point2d(centers[i][3], centers[i][4]), 2, colour, 2);
     }
 }
 
 /*
  * Display a single pixel wide contour around the clusters.
  *
- * Input : The target image (IplImage*) and contour colour (CvScalar).
+ * Input : The target image (cv::Mat) and contour colour (cv::Scalar).
  * Output: -
  */
-void Slic::display_contours(IplImage *image, CvScalar colour) {
+void Slic::display_contours(cv::Mat &image, cv::Vec3b colour) {
     const int dx8[8] = {-1, -1,  0,  1, 1, 1, 0, -1};
 	const int dy8[8] = { 0, -1, -1, -1, 0, 1, 1,  1};
 	
 	/* Initialize the contour vector and the matrix detailing whether a pixel
 	 * is already taken to be a contour. */
-	vector<CvPoint> contours;
+	vector<cv::Point> contours;
 	vec2db istaken;
-	for (int i = 0; i < image->width; i++) { 
+	for (int i = 0; i < image.cols; i++) { 
         vector<bool> nb;
-        for (int j = 0; j < image->height; j++) {
+        for (int j = 0; j < image.rows; j++) {
             nb.push_back(false);
         }
         istaken.push_back(nb);
     }
     
     /* Go through all the pixels. */
-    for (int i = 0; i < image->width; i++) {
-        for (int j = 0; j < image->height; j++) {
+    for (int i = 0; i < image.cols; i++) {
+        for (int j = 0; j < image.rows; j++) {
             int nr_p = 0;
             
             /* Compare the pixel to its 8 neighbours. */
             for (int k = 0; k < 8; k++) {
                 int x = i + dx8[k], y = j + dy8[k];
                 
-                if (x >= 0 && x < image->width && y >= 0 && y < image->height) {
+                if (x >= 0 && x < image.cols && y >= 0 && y < image.rows) {
                     if (istaken[x][y] == false && clusters[i][j] != clusters[x][y]) {
                         nr_p += 1;
                     }
@@ -328,7 +328,7 @@ void Slic::display_contours(IplImage *image, CvScalar colour) {
             
             /* Add the pixel to the contour list if desired. */
             if (nr_p >= 2) {
-                contours.push_back(cvPoint(i,j));
+                contours.push_back(cv::Point(i,j));
                 istaken[i][j] = true;
             }
         }
@@ -336,7 +336,7 @@ void Slic::display_contours(IplImage *image, CvScalar colour) {
     
     /* Draw the contour pixels. */
     for (int i = 0; i < (int)contours.size(); i++) {
-        cvSet2D(image, contours[i].y, contours[i].x, colour);
+        image.at<Vec3b>(contours[i].y, contours[i].x) = colour;
     }
 }
 
@@ -344,36 +344,29 @@ void Slic::display_contours(IplImage *image, CvScalar colour) {
  * Give the pixels of each cluster the same colour values. The specified colour
  * is the mean RGB colour per cluster.
  *
- * Input : The target image (IplImage*).
+ * Input : The target image (cv::Mat).
  * Output: -
  */
-void Slic::colour_with_cluster_means(IplImage *image) {
-    vector<CvScalar> colours(centers.size());
+void Slic::colour_with_cluster_means(cv::Mat &image) {
+    vector<cv::Vec3b> colours(centers.size());
     
     /* Gather the colour values per cluster. */
-    for (int i = 0; i < image->width; i++) {
-        for (int j = 0; j < image->height; j++) {
+    for (int i = 0; i < image.cols; i++) {
+        for (int j = 0; j < image.rows; j++) {
             int index = clusters[i][j];
-            CvScalar colour = cvGet2D(image, j, i);
-            
-            colours[index].val[0] += colour.val[0];
-            colours[index].val[1] += colour.val[1];
-            colours[index].val[2] += colour.val[2];
+            colours[index] += image.at<Vec3b>(j, i);
         }
     }
     
     /* Divide by the number of pixels per cluster to get the mean colour. */
     for (int i = 0; i < (int)colours.size(); i++) {
-        colours[i].val[0] /= center_counts[i];
-        colours[i].val[1] /= center_counts[i];
-        colours[i].val[2] /= center_counts[i];
+        colours[i] /= center_counts[i];
     }
     
     /* Fill in. */
-    for (int i = 0; i < image->width; i++) {
-        for (int j = 0; j < image->height; j++) {
-            CvScalar ncolour = colours[clusters[i][j]];
-            cvSet2D(image, j, i, ncolour);
+    for (int i = 0; i < image.cols; i++) {
+        for (int j = 0; j < image.rows; j++) {
+            image.at<Vec3b>(j, i) = colours[clusters[i][j]];;
         }
     }
 }

--- a/slic.h
+++ b/slic.h
@@ -13,13 +13,14 @@
  * over-segmentations in an OpenCV-based environment.
  */
 
-#include <opencv/cv.h>
-#include <opencv/highgui.h>
 #include <stdio.h>
 #include <math.h>
 #include <vector>
 #include <float.h>
 using namespace std;
+
+#include <opencv2/opencv.hpp>
+using namespace cv;
 
 /* 2d matrices are handled by 2d vectors. */
 #define vec2dd vector<vector<double> >
@@ -51,13 +52,13 @@ class Slic {
         int step, nc, ns;
         
         /* Compute the distance between a center and an individual pixel. */
-        double compute_dist(int ci, CvPoint pixel, CvScalar colour);
+        double compute_dist(int ci, cv::Point pixel, cv::Scalar colour);
         /* Find the pixel with the lowest gradient in a 3x3 surrounding. */
-        CvPoint find_local_minimum(IplImage *image, CvPoint center);
+        cv::Point find_local_minimum(const cv::Mat &image, cv::Point center);
         
         /* Remove and initialize the 2d vectors. */
         void clear_data();
-        void init_data(IplImage *image);
+        void init_data(const cv::Mat &image);
 
     public:
         /* Class constructors and deconstructors. */
@@ -65,14 +66,14 @@ class Slic {
         ~Slic();
         
         /* Generate an over-segmentation for an image. */
-        void generate_superpixels(IplImage *image, int step, int nc);
+        void generate_superpixels(const cv::Mat &image, int step, int nc);
         /* Enforce connectivity for an image. */
-        void create_connectivity(IplImage *image);
+        void create_connectivity(const cv::Mat &image);
         
         /* Draw functions. Resp. displayal of the centers and the contours. */
-        void display_center_grid(IplImage *image, CvScalar colour);
-        void display_contours(IplImage *image, CvScalar colour);
-        void colour_with_cluster_means(IplImage *image);
+        void display_center_grid(cv::Mat &image, cv::Vec3b colour);
+        void display_contours(cv::Mat &image, cv::Vec3b colour);
+        void colour_with_cluster_means(cv::Mat &image);
 };
 
 #endif

--- a/slic.h
+++ b/slic.h
@@ -20,12 +20,12 @@
 using namespace std;
 
 #include <opencv2/opencv.hpp>
-using namespace cv;
+//using namespace cv;
 
 /* The number of iterations run by the clustering algorithm. */
 #define NR_ITERATIONS 10
 
-typedef Vec<double, 5> Vec5d;
+typedef cv::Vec<double, 5> Vec5d;
 
 
 /*
@@ -38,8 +38,8 @@ typedef Vec<double, 5> Vec5d;
 class Slic {
     private:
         /* The cluster assignments and distance values for each pixel. */
-        Mat_<int> clusters;
-        Mat_<double> distances;
+        cv::Mat_<int> clusters;
+        cv::Mat_<double> distances;
         
         /* The LAB and xy values of the centers. */
         cv::Mat_<Vec5d> centers;
@@ -51,9 +51,9 @@ class Slic {
         int step, nc, ns;
         
         /* Compute the distance between a center and an individual pixel. */
-        double compute_dist(int ci, cv::Point pixel, cv::Scalar colour);
+        double compute_dist(int ci, cv::Point pixel, cv::Vec3b colour);
         /* Find the pixel with the lowest gradient in a 3x3 surrounding. */
-        cv::Point find_local_minimum(const cv::Mat_<Vec3b> &image, cv::Point center);
+        cv::Point find_local_minimum(const cv::Mat_<cv::Vec3b> &image, cv::Point center);
         
         /* Remove and initialize the 2d vectors. */
         void clear_data();

--- a/slic.h
+++ b/slic.h
@@ -70,7 +70,7 @@ class Slic {
         void create_connectivity(const cv::Mat &image);
         
         /* Draw functions. Resp. displayal of the centers and the contours. */
-        void display_center_grid(cv::Mat &image, cv::Vec3b colour);
+        void display_center_grid(cv::Mat &image, cv::Scalar colour);
         void display_contours(cv::Mat &image, cv::Vec3b colour);
         void colour_with_cluster_means(cv::Mat &image);
 };

--- a/slic.h
+++ b/slic.h
@@ -22,12 +22,11 @@ using namespace std;
 #include <opencv2/opencv.hpp>
 using namespace cv;
 
-/* 2d matrices are handled by 2d vectors. */
-#define vec2dd vector<vector<double> >
-#define vec2di vector<vector<int> >
-#define vec2db vector<vector<bool> >
 /* The number of iterations run by the clustering algorithm. */
 #define NR_ITERATIONS 10
+
+typedef Vec<double, 5> Vec5d;
+
 
 /*
  * class Slic.
@@ -39,11 +38,11 @@ using namespace cv;
 class Slic {
     private:
         /* The cluster assignments and distance values for each pixel. */
-        vec2di clusters;
-        vec2dd distances;
+        Mat_<int> clusters;
+        Mat_<double> distances;
         
         /* The LAB and xy values of the centers. */
-        vec2dd centers;
+        cv::Mat_<Vec5d> centers;
         /* The number of occurences of each center. */
         vector<int> center_counts;
         
@@ -54,7 +53,7 @@ class Slic {
         /* Compute the distance between a center and an individual pixel. */
         double compute_dist(int ci, cv::Point pixel, cv::Scalar colour);
         /* Find the pixel with the lowest gradient in a 3x3 surrounding. */
-        cv::Point find_local_minimum(const cv::Mat &image, cv::Point center);
+        cv::Point find_local_minimum(const cv::Mat_<Vec3b> &image, cv::Point center);
         
         /* Remove and initialize the 2d vectors. */
         void clear_data();

--- a/test_slic.cpp
+++ b/test_slic.cpp
@@ -7,26 +7,26 @@
  * superpixel algorithm, as implemented in slic.h and slic.cpp.
  */
  
-#include <opencv/cv.h>
-#include <opencv/highgui.h>
 #include <stdio.h>
 #include <math.h>
 #include <vector>
 #include <float.h>
 using namespace std;
 
+#include <opencv2/opencv.hpp>
 #include "slic.h"
+using namespace cv;
 
 int main(int argc, char *argv[]) {
     /* Load the image and convert to Lab colour space. */
-    IplImage *image = cvLoadImage(argv[1], 1);
-    IplImage *lab_image = cvCloneImage(image);
-    cvCvtColor(image, lab_image, CV_BGR2Lab);
+    Mat image = imread("dog.png", 1);
+    Mat lab_image;
+    cvtColor(image, lab_image, COLOR_BGR2Lab);
     
     /* Yield the number of superpixels and weight-factors from the user. */
-    int w = image->width, h = image->height;
-    int nr_superpixels = atoi(argv[2]);
-    int nc = atoi(argv[3]);
+    int w = image.cols, h = image.rows;
+    int nr_superpixels = 400;
+    int nc = 40;
 
     double step = sqrt((w * h) / (double) nr_superpixels);
     
@@ -36,8 +36,7 @@ int main(int argc, char *argv[]) {
     slic.create_connectivity(lab_image);
     
     /* Display the contours and show the result. */
-    slic.display_contours(image, CV_RGB(255,0,0));
-    cvShowImage("result", image);
-    cvWaitKey(0);
-    cvSaveImage(argv[4], image);
+    slic.display_contours(image, Vec3b(0,0,255));
+    imshow("result", image);
+    waitKey(0);
 }

--- a/test_slic.cpp
+++ b/test_slic.cpp
@@ -17,6 +17,7 @@ using namespace std;
 #include "slic.h"
 using namespace cv;
 
+
 int main(int argc, char *argv[]) {
     /* Load the image and convert to Lab colour space. */
     Mat image = imread("dog.png", 1);
@@ -29,14 +30,14 @@ int main(int argc, char *argv[]) {
     int nc = 40;
 
     double step = sqrt((w * h) / (double) nr_superpixels);
-    
+
     /* Perform the SLIC superpixel algorithm. */
     Slic slic;
-    slic.generate_superpixels(lab_image, step, nc);
+    slic.generate_superpixels(lab_image, int(step), nc);
     slic.create_connectivity(lab_image);
+    slic.display_contours(image, Vec3b(0,0,255));
     
     /* Display the contours and show the result. */
-    slic.display_contours(image, Vec3b(0,0,255));
     imshow("result", image);
     waitKey(0);
 }


### PR DESCRIPTION
opencv changed to a c++ api (using cv::Mat) in 2010, the upcoming 3.0 version will make it much harder to use IplImages, let's change those !

(using templated Mat_<double> instead of vector<vector<double> also reduces a third of the time needed.)
