### PR TITLE
Fix test_slic.cpp

### DIFF
--- a/test_slic.cpp
+++ b/test_slic.cpp
@@ -15,7 +15,7 @@
 #include <float.h>
 using namespace std;
 
-#include "slic.h"
+#include "slic.cpp"
 
 int main(int argc, char *argv[]) {
     /* Load the image and convert to Lab colour space. */


### PR DESCRIPTION
Earlier test_slic.cpp was including 'slic.h' instead of 'slic.cpp'.
slic.cpp is already including slic.h so including slic.h was creating an error. Fixed that.